### PR TITLE
Fix ::digest-fn spec

### DIFF
--- a/src/valuehash/specs.clj
+++ b/src/valuehash/specs.clj
@@ -8,11 +8,13 @@
 (defn byte-array? [obj] (instance? byte-array-class obj))
 (defn input-stream? [obj] (instance? java.io.InputStream obj))
 
+(s/def ::input-stream (s/spec input-stream? :gen #(->> (byte-array 0)
+                                                       (io/input-stream)
+                                                       (gen/return))))
+
 (s/def ::digest-fn
   (s/fspec
-   :args (s/cat :input-stream (s/spec input-stream? :gen #(->> (byte-array 0)
-                                                               (io/input-stream)
-                                                               (gen/return))))
+   :args (s/cat :input-stream ::input-stream)
    :ret byte-array?))
 
 (s/fdef valuehash.api/digest

--- a/src/valuehash/specs.clj
+++ b/src/valuehash/specs.clj
@@ -1,5 +1,7 @@
 (ns valuehash.specs
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [clojure.java.io :as io]))
 
 (def byte-array-class (class (byte-array 0)))
 
@@ -8,8 +10,10 @@
 
 (s/def ::digest-fn
   (s/fspec
-    :args (s/cat :input-stream input-stream?)
-    :ret byte-array?))
+   :args (s/cat :input-stream (s/spec input-stream? :gen #(->> (byte-array 0)
+                                                               (io/input-stream)
+                                                               (gen/return))))
+   :ret byte-array?))
 
 (s/fdef valuehash.api/digest
   :args (s/cat :digest-fn ::digest-fn, :obj any?)


### PR DESCRIPTION
A simple generator for `java.io.InputStream`, the absence of which was causing Clojud tests to fail with spec checking switched on.